### PR TITLE
Add unit tests for CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+spec/fixtures/crlf.js eol=crlf
+spec/fixtures/crlf.*.js eol=crlf

--- a/spec/fixtures/crlf.cutLines.js
+++ b/spec/fixtures/crlf.cutLines.js
@@ -1,0 +1,10 @@
+class Example {
+    run() {
+        console.log('Hello World');
+        console.log('Debugging off');
+        console.log('Goodbye');
+    }
+
+    a() {
+    }
+}

--- a/spec/fixtures/crlf.insertBlanks.false.js
+++ b/spec/fixtures/crlf.insertBlanks.false.js
@@ -1,0 +1,17 @@
+class Example {
+    run() {
+        console.log('Hello World');
+
+
+
+        console.log('Debugging off');
+
+        console.log('Goodbye');
+    }
+
+    a() {
+
+
+
+    }
+}

--- a/spec/fixtures/crlf.insertBlanks.true.js
+++ b/spec/fixtures/crlf.insertBlanks.true.js
@@ -1,0 +1,17 @@
+class Example {
+    run() {
+        console.log('Hello World');
+
+        console.log('Debugging on');
+
+
+
+        console.log('Goodbye');
+    }
+
+    a() {
+
+        console.log('a');
+
+    }
+}

--- a/spec/fixtures/crlf.js
+++ b/spec/fixtures/crlf.js
@@ -1,0 +1,17 @@
+class Example {
+    run() {
+        console.log('Hello World');
+        /// #if DEBUG
+        console.log('Debugging on');
+        /// #else
+        console.log('Debugging off');
+        /// #endif
+        console.log('Goodbye');
+    }
+
+    a() {
+        /// #if A
+        console.log('a');
+        /// #endif
+    }
+}

--- a/spec/fixtures/simple.out.js
+++ b/spec/fixtures/simple.out.js
@@ -1,6 +1,0 @@
-class Example {
-    run() {
-        console.log('Hello World');
-        console.log('Goodbye');
-    }
-}

--- a/spec/index-spec.js
+++ b/spec/index-spec.js
@@ -65,4 +65,48 @@ describe('gulp-ifdef', function () {
                 done();
             });
     });
+
+    describe('with CRLF line endings', function () {
+        it('inserts blank lines for blocks that evaluate to false', function (done) {
+            gulp.src(['spec/fixtures/crlf.js'])
+                .pipe(ifdef({ DEBUG: false, A: false }, { extname: ['js'] }))
+                .on('data', file => {
+                    const expected = fs.readFileSync('spec/fixtures/crlf.insertBlanks.false.js', 'utf8');
+                    expect(file.contents.toString()).toEqual(expected);
+
+                    // confirm we're actually testing a CRLF file
+                    expect(expected.split(/\n/).length).toEqual(expected.split(/\r\n/).length);
+                    done();
+                })
+                .on('error', error => done(error));
+        });
+
+        it('retains blocks that evaluate to true', function (done) {
+            gulp.src(['spec/fixtures/crlf.js'])
+                .pipe(ifdef({ DEBUG: true, A: true }, { extname: ['js'] }))
+                .on('data', file => {
+                    const expected = fs.readFileSync('spec/fixtures/crlf.insertBlanks.true.js', 'utf8');
+                    expect(file.contents.toString()).toEqual(expected);
+
+                    // confirm we're actually testing a CRLF file
+                    expect(expected.split(/\n/).length).toEqual(expected.split(/\r\n/).length);
+                    done();
+                })
+                .on('error', error => done(error));
+        });
+
+        it('removes lines if insertBlanks is false', function (done) {
+            gulp.src(['spec/fixtures/crlf.js'])
+                .pipe(ifdef({ DEBUG: false, A: false }, { extname: ['js'], insertBlanks: false }))
+                .on('data', file => {
+                    const expected = fs.readFileSync('spec/fixtures/crlf.cutLines.js', 'utf8');
+                    expect(file.contents.toString()).toEqual(expected);
+
+                    // confirm we're actually testing a CRLF file
+                    expect(expected.split(/\n/).length).toEqual(expected.split(/\r\n/).length);
+                    done();
+                })
+                .on('error', error => done(error));
+        });
+    });
 });


### PR DESCRIPTION
### SUMMARY

Add unit tests for DOS-style (CRLF) line endings.

### DETAILS

- Remove an unused fixture file
- Add unit tests for CRLF line endings

No changes to the actual behavior in this PR, just ensuring future edits don't break existing functionality.

### TESTS

Local `npm test` passes in node v8 & node v10.