### PR TITLE
Support nested if blocks

### DIFF
--- a/spec/fixtures/complexError.js
+++ b/spec/fixtures/complexError.js
@@ -1,0 +1,12 @@
+class Example {
+    a() {
+        /// #if A
+        console.log('a');
+        /// #endif
+
+        /// #if B
+        console.log('b');
+        /// #endif
+        /// #endif
+    }
+}

--- a/spec/fixtures/doubleElse.js
+++ b/spec/fixtures/doubleElse.js
@@ -1,0 +1,11 @@
+class Example {
+    a() {
+        /// #if A
+        console.log('a');
+        /// #else
+        console.log('b');
+        /// #else
+        console.log('c');
+        /// #endif
+    }
+}

--- a/spec/fixtures/doubleEndif.js
+++ b/spec/fixtures/doubleEndif.js
@@ -1,0 +1,7 @@
+class Example {
+    a() {
+        // if A
+        console.log('a');
+        /// #endif
+    }
+}

--- a/spec/fixtures/nested.cutLines.js
+++ b/spec/fixtures/nested.cutLines.js
@@ -1,30 +1,10 @@
 class Example {
     run() {
-
         console.log("A is enabled");
-
-
-
         console.log("A-B");
-
         console.log("A-B+C");
 
-
-
-
-
-
-
-
-
-
-
-
         console.log("this stuff will");
-
-
-
-
 
     }
 }

--- a/spec/fixtures/nested.js
+++ b/spec/fixtures/nested.js
@@ -22,5 +22,9 @@ class Example {
         /// #if C
         console.log("this stuff will");
         /// #endif
-   }
+
+        /// #if B
+        console.log("not this stuff");
+        /// #endif
+    }
 }

--- a/spec/fixtures/nested.js
+++ b/spec/fixtures/nested.js
@@ -1,0 +1,26 @@
+class Example {
+    run() {
+        /// #if A
+        console.log("A is enabled");
+        /// #if B
+        console.log("A+B");
+        /// #else
+        console.log("A-B");
+        /// #if C
+        console.log("A-B+C");
+        /// #else
+        console.log("A-B-C");
+        /// #endif
+        /// #endif
+        /// #else
+        console.log("A is disabled");
+        /// #if C
+        console.log("this stuff won't matter");
+        /// #endif
+        /// #endif
+
+        /// #if C
+        console.log("this stuff will");
+        /// #endif
+   }
+}

--- a/spec/fixtures/nested.out.js
+++ b/spec/fixtures/nested.out.js
@@ -1,0 +1,26 @@
+class Example {
+    run() {
+
+        console.log("A is enabled");
+
+
+
+        console.log("A-B");
+
+        console.log("A-B+C");
+
+
+
+
+
+
+
+
+
+
+
+
+        console.log("this stuff will");
+
+   }
+}

--- a/spec/fixtures/unexpectedElse.js
+++ b/spec/fixtures/unexpectedElse.js
@@ -1,0 +1,9 @@
+class Example {
+    a() {
+        // if A
+        console.log('a');
+        /// #else
+        console.log('b');
+        /// #endif
+    }
+}

--- a/spec/index-spec.js
+++ b/spec/index-spec.js
@@ -115,4 +115,25 @@ describe('gulp-ifdef', function () {
         })
         .on('error', error => done(error));
     });
+
+    it('prints debugging information if verbose mode is enabled', function (done) {
+        spyOn(console, 'log');
+
+        gulp.src(['spec/fixtures/nested.js'])
+        .pipe(ifdef({ A: true, B: false, C: true }, { extname: ['js'], verbose: true, insertBlanks: false }))
+        .on('data', file => {
+            const expected = fs.readFileSync('spec/fixtures/nested.cutLines.js', 'utf8');
+            expect(file.contents.toString()).toEqual(expected);
+            expect(console.log.calls.allArgs()).toEqual([
+                ['Condition (#if C) is true: keeping lines 10-10 of 9-13'],
+                ['Condition (#if B) is false: keeping lines 8-13 of 5-14'],
+                ['Condition (#if C) is true: keeping lines 18-18 of 17-19'],
+                ['Condition (#if A) is true: keeping lines 4-14 of 3-20'],
+                ['Condition (#if C) is true: keeping lines 23-23 of 22-24'],
+                ['Condition (#if B) is false: removing lines 26-28']
+            ]);
+            done();
+        })
+        .on('error', error => done(error));
+    });
 });

--- a/spec/index-spec.js
+++ b/spec/index-spec.js
@@ -104,4 +104,15 @@ describe('gulp-ifdef', function () {
                 done();
             });
     });
+
+    it('correctly handles nested if blocks', function (done) {
+        gulp.src(['spec/fixtures/nested.js'])
+        .pipe(ifdef({ A: true, B: false, C: true }, { extname: ['js'] }))
+        .on('data', file => {
+            const expected = fs.readFileSync('spec/fixtures/nested.out.js', 'utf8');
+            expect(file.contents.toString()).toEqual(expected);
+            done();
+        })
+        .on('error', error => done(error));
+    });
 });

--- a/spec/index-spec.js
+++ b/spec/index-spec.js
@@ -55,13 +55,52 @@ describe('gulp-ifdef', function () {
     it('throws an error if an #if block is missing an #endif', function (done) {
         gulp.src(['spec/fixtures/missingEndif.js'])
             .pipe(ifdef({ DEBUG: false, A: false }, { extname: ['js'] }))
-            .on('data', file => {
-                const expected = fs.readFileSync('spec/fixtures/simple.insertBlanks.false.js', 'utf8');
-                expect(file.contents.toString()).toEqual(expected);
+            .on('data', done.fail)
+            .on('error', error => {
+                expect(String(error)).toEqual('Error: gulp-ifdef: #if without #endif on line 3:         /// #if A');
+                done();
+            });
+    });
+
+    it('throws an error on unexpected #endif', function (done) {
+        gulp.src(['spec/fixtures/doubleEndif.js'])
+            .pipe(ifdef({ DEBUG: false, A: false }, { extname: ['js'] }))
+            .on('data', done.fail)
+            .on('error', error => {
+                expect(String(error)).toEqual('Error: gulp-ifdef: #endif outside of #if block on line 5:         /// #endif');
+                done();
+            });
+    });
+
+    it('throws an error on double #else', function (done) {
+        gulp.src(['spec/fixtures/doubleElse.js'])
+            .pipe(ifdef({ DEBUG: false, A: false }, { extname: ['js'] }))
+            .on('data', done.fail)
+            .on('error', error => {
+                expect(String(error)).toEqual('Error: gulp-ifdef: second #else in #if block on line 7:         /// #else');
+                done();
+            });
+    });
+
+    it('throws an error on unexpected #else', function (done) {
+        gulp.src(['spec/fixtures/unexpectedElse.js'])
+            .pipe(ifdef({ DEBUG: false, A: false }, { extname: ['js'] }))
+            .on('data', done.fail)
+            .on('error', error => {
+                expect(String(error)).toEqual('Error: gulp-ifdef: #else outside of #if block on line 5:         /// #else');
+                done();
+            });
+    });
+
+    it('throws an error on the correct line when cutting lines', function (done) {
+        gulp.src(['spec/fixtures/complexError.js'])
+            .pipe(ifdef({ A: false, B: false }, { extname: ['js'], insertBlanks: false }))
+            .on('data', result => {
+                console.log(result.contents.toString());
                 done();
             })
             .on('error', error => {
-                expect(String(error)).toEqual('Error: gulp-ifdef: #if without #endif in line 3');
+                expect(String(error)).toEqual('Error: gulp-ifdef: #endif outside of #if block on line 10:         /// #endif');
                 done();
             });
     });


### PR DESCRIPTION
### SUMMARY

- Add support for nested #if blocks
- Print more detailed error messages and (if enabled) debugging information
- Fixes https://github.com/yuxiaomin/gulp-ifdef/issues/1

### DETAILS

This ended up touching a lot more code than I intended, mostly due to getting accurate line number output in log messages and errors when you are not inserting blanks.

Internally, the basic changes here are:

- Change the parsing to keep a list of lines we _plan_ on cutting, and then once the entire file is parsed, cut them all (either inserting blanks or removing them, as desired), and return the result and the line mappings.  This change makes the rest of the code much simpler, since all line numbers are "fixed" during parsing.

- Refactor the parsing method to use a stack, so we can nest #if-#endif blocks.  Beefed up the types of errors output so we can inform the user about various issues (#endif without #if, unexpected #else, etc.).

- Improve verbose logging (for example, correctly identify the plan if a condition fails but there is an else block we plan to keep).

- Add unit tests for all the above, to protect against future regressions.

### TESTS

- Local `npm test` passes on node v8 and node v10.